### PR TITLE
Add CodeAgent CLI Launcher privacy policy page

### DIFF
--- a/src/layouts/MarkdownLayout.astro
+++ b/src/layouts/MarkdownLayout.astro
@@ -1,0 +1,106 @@
+---
+import Layout from "./Layout.astro";
+
+export interface Props {
+  frontmatter: {
+    title: string;
+    description: string;
+  };
+}
+
+const { frontmatter } = Astro.props;
+---
+
+<Layout title={frontmatter.title} description={frontmatter.description}>
+  <main class="markdown">
+    <slot />
+  </main>
+</Layout>
+
+<style lang="scss" is:global>
+  .markdown {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 48px 20px 80px;
+    line-height: 1.75;
+    color: #333;
+
+    h1 {
+      font-size: 28px;
+      letter-spacing: 0.5px;
+      padding-bottom: 12px;
+      margin-bottom: 24px;
+      border-bottom: 2px solid #fbbf5d;
+    }
+
+    h2 {
+      font-size: 20px;
+      margin-top: 40px;
+      margin-bottom: 12px;
+    }
+
+    p {
+      margin-bottom: 16px;
+    }
+
+    em {
+      color: #757575;
+      font-style: normal;
+      font-size: 14px;
+    }
+
+    ul {
+      padding-left: 24px;
+      margin-bottom: 16px;
+    }
+
+    li {
+      margin-bottom: 6px;
+    }
+
+    code {
+      background-color: #f4f4f7;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 0.9em;
+      font-family:
+        ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 16px 0 24px;
+      font-size: 14px;
+      display: block;
+      overflow-x: auto;
+    }
+
+    thead {
+      background-color: #f4f4f7;
+    }
+
+    th,
+    td {
+      text-align: left;
+      padding: 10px 12px;
+      border: 1px solid #e0e0e0;
+      vertical-align: top;
+    }
+
+    th {
+      font-weight: 600;
+    }
+
+    strong {
+      font-weight: 600;
+    }
+
+    a {
+      color: #3273dc;
+      &:hover {
+        opacity: 0.6;
+      }
+    }
+  }
+</style>

--- a/src/pages/product/codeagent-cli-launcher/privacy-policy.md
+++ b/src/pages/product/codeagent-cli-launcher/privacy-policy.md
@@ -1,0 +1,43 @@
+---
+layout: ../../../layouts/MarkdownLayout.astro
+title: "Privacy Policy — CodeAgent CLI Launcher"
+description: "Privacy policy for the CodeAgent CLI Launcher browser extension."
+---
+
+# Privacy Policy — CodeAgent CLI Launcher
+
+_Last updated: 2026-04-18_
+
+## Summary
+CodeAgent CLI Launcher ("the extension") does **not** collect, transmit, sell, or share any user data. All configuration is stored locally on the user's device and never leaves the browser.
+
+## Data the extension handles
+The extension reads and/or stores the following data **only on the local device**:
+
+| Data | Purpose | Storage |
+|---|---|---|
+| URL of the currently active tab | Parse GitHub owner/repo/issue/PR to build a launch command | In-memory, not persisted |
+| Local repository base path (e.g. `~/repos`) | Build the `cd` portion of the generated command | `chrome.storage.local` |
+| User-defined commands (name, prompt, page types) | Populate the command dropdown and export/import feature | `chrome.storage.local` |
+
+The extension does **not** read page contents, cookies, credentials, or any information outside of the active tab's URL.
+
+## Data transmission
+The extension performs **no network requests**. Nothing is sent to the developer, to Google, or to any third party.
+
+## Permissions justification
+- `activeTab`: required to read the current tab's URL (only when the user clicks the extension icon) in order to detect a GitHub repo/issue/PR.
+- `clipboardWrite`: required to copy the generated shell command to the clipboard on user action.
+- `storage`: required to persist the user's base path and custom commands across sessions.
+
+## Third-party services
+None. The extension has no analytics, no remote configuration, no telemetry.
+
+## Children's privacy
+The extension does not knowingly collect data from anyone, including children under 13.
+
+## Changes to this policy
+If the data handling behavior ever changes, this document will be updated and the "Last updated" date revised.
+
+## Contact
+Questions or concerns: open an issue at the project's GitHub repository, or contact the developer via the email listed on the Chrome Web Store developer page.


### PR DESCRIPTION
## Summary
- Add privacy policy page at `/product/codeagent-cli-launcher/privacy-policy` for the CodeAgent CLI Launcher Chrome extension
- Add reusable `MarkdownLayout.astro` with minimal styling (container width, headings, tables, code, lists)

## Test plan
- [x] `npm run dev` and open http://localhost:4321/product/codeagent-cli-launcher/privacy-policy
- [x] Verify layout renders with proper spacing, table, and code styling
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)