### PR TITLE
fix: allow @parcel/watcher build script for Linux CI

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages: []
 onlyBuiltDependencies:
   - sharp
   - esbuild
+  - "@parcel/watcher"
 strictDepBuilds: true
 minimumReleaseAge: 4320
 blockExoticSubdeps: true


### PR DESCRIPTION
## Summary
- Cloudflare Pages (Linux) のビルドが `ERR_PNPM_IGNORED_BUILDS` で失敗していた問題を修正
- `@parcel/watcher` を `onlyBuiltDependencies` に追加

## 背景
macOS は prebuilt バイナリで postinstall がスキップされるため、ローカル検証では検知できなかった。Linux では native build が必須で、`strictDepBuilds: true` 下では ignored build が install を exit 1 させる。

## 検証
- [x] ローカル `pnpm install` 成功（EXIT=0）
- [x] Cloudflare Pages のビルド再実行で成功すること

## Test plan
- [x] CF Pages のデプロイが緑になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)